### PR TITLE
Avoid assigning multiple TCP ports for Deck and Gate

### DIFF
--- a/spinnaker-config/overlays/keel/patch-deck.yml
+++ b/spinnaker-config/overlays/keel/patch-deck.yml
@@ -8,6 +8,8 @@ spec:
   type: LoadBalancer
   ports:
     - port: 9000
+      protocol: TCP
+      targetPort: 9000
       $patch: delete
     - port: 80
       protocol: TCP

--- a/spinnaker-config/overlays/keel/patch-gate.yml
+++ b/spinnaker-config/overlays/keel/patch-gate.yml
@@ -8,6 +8,8 @@ spec:
   type: LoadBalancer
   ports:
     - port: 8084
+      protocol: TCP
+      targetPort: 8084
       $patch: delete
     - port: 80
       protocol: TCP


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
As of kustomize/v4.1.2, it seems `$patch: delete` requires to specify full contents of deleting item to make sure item to be deleted from a list. Because Kustomize didn't really removed the surplus port entry, Kubernetes requires to assign unique name to each port entries on deployment.

    Error from server (Invalid): error when creating "STDIN": Service "deck" is invalid: [spec.ports[0].name: Required value, spec.ports[1].name: Required value]
    Error from server (Invalid): error when creating "STDIN": Service "gate" is invalid: [spec.ports[0].name: Required value, spec.ports[1].name: Required value]
